### PR TITLE
Add OGER

### DIFF
--- a/oger/Chart.yaml
+++ b/oger/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: oger
+description: A Helm chart for OGER
+
+type: application
+
+version: 0.1.0
+
+appVersion: 0.1.0
+
+

--- a/oger/README.md
+++ b/oger/README.md
@@ -1,0 +1,10 @@
+# oger.apps.renci.org
+
+Basic Helm instructions for a Docker image of [OGER](https://github.com/OntoGene/OGER/)
+running with a similar ontology setup to
+[Omnicorp](https://github.com/NCATS-Gamma/omnicorp). We should increase the memory 
+if we need to test this for speed, but the current settings are fine for general
+testing of OGER.
+
+Once started, this will be accessible at https://oger.apps.renci.org/ from within
+the RENCI network.

--- a/oger/templates/deployment.yaml
+++ b/oger/templates/deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Values.app.name }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.app.name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    service-type: webserver
+spec:
+  serviceName: "oger"
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Values.app.name }}-deployment
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      service-type: webserver
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Values.app.name }}-deployment
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        service-type: webserver
+    spec:
+      containers:
+        - name: {{ .Values.app.name }}-server
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+          ports:
+            - name: http
+              containerPort: {{ .Values.app.port }}
+              protocol: TCP
+          resources: {{ toYaml .Values.service.resources | nindent 12 }}

--- a/oger/templates/ingress.yaml
+++ b/oger/templates/ingress.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Values.app.name }}-ingress
+  annotations:
+    {{ .Values.ingress.annotations | toYaml | nindent 4 }}
+spec:
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host | quote }}
+      secretName: {{ .Values.ingress.host }}-tls
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: "/"
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Values.app.name }}-service
+                port:
+                  number: {{ .Values.app.port }}

--- a/oger/templates/service.yaml
+++ b/oger/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.app.name }}
+  name: {{ .Values.app.name }}-service
   labels:
     app.kubernetes.io/name: {{ .Values.app.name }}-service
     app.kubernetes.io/instance: {{ .Values.app.name }}-service

--- a/oger/templates/service.yaml
+++ b/oger/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.app.name }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.app.name }}-service
+    app.kubernetes.io/instance: {{ .Values.app.name }}-service
+    service-type: webserver
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.app.port }}
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ .Values.app.name }}-deployment
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    service-type: webserver

--- a/oger/values.yaml
+++ b/oger/values.yaml
@@ -14,7 +14,13 @@ service:
       cpu: 1
     limits:
       memory: 24Gi
-      cpu: 3
+      cpu: 1
 
 ingress:
   host: oger.apps.renci.org
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+
+app:
+  name: oger
+  port: 8080

--- a/oger/values.yaml
+++ b/oger/values.yaml
@@ -1,0 +1,20 @@
+replicaCount: 1
+
+image:
+  repository: "ggvaidya/oger"
+  tag: "dev"
+  pullPolicy: Always
+
+service:
+  type: ClusterIP
+  port: 8080
+  resources:
+    requests:
+      memory: 20Gi
+      cpu: 1
+    limits:
+      memory: 24Gi
+      cpu: 3
+
+ingress:
+  host: oger.apps.renci.org


### PR DESCRIPTION
Adds basic Helm instructions for a Docker image of [OGER](https://github.com/OntoGene/OGER/) running with a similar ontology setup to [Omnicorp](https://github.com/NCATS-Gamma/omnicorp). We should increase the memory if we need to test this for speed, but the current settings are fine for general testing of OGER.